### PR TITLE
bump to ink 4.1

### DIFF
--- a/contracts/psp22_pallet_wrapper/Cargo.toml
+++ b/contracts/psp22_pallet_wrapper/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "~4.0.0", default-features = false }
+ink = { version = "~4.1.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "~4.0.0", default-features = false }
+ink = { version = "~4.1.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/crates/dapps-staking/Cargo.toml
+++ b/crates/dapps-staking/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "~4.0.0", default-features = false }
+ink = { version = "~4.1.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/assets/Cargo.toml
+++ b/examples/assets/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "~4.0.0", default-features = false }
+ink = { version = "~4.1.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/dapps-staking/Cargo.toml
+++ b/examples/dapps-staking/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "~4.0.0", default-features = false }
+ink = { version = "~4.1.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
Currently, compilation fails due to unresolvable Ink version:

    `cargo metadata` exited with an error:     Updating crates.io index
        Updating git repository `https://github.com/727-Ventures/openbrush-contracts`
        Updating git repository `https://github.com/727-ventures/pallet-assets-chain-extension`
        Updating git repository `https://github.com/727-Ventures/obce`
    error: failed to select a version for `ink`.
        ... required by package `asset_wrapper v0.1.0 (/tmp/chain-extension-contracts/examples/assets)`
    versions that meet the requirements `~4.0.0` are: 4.0.1, 4.0.0

    all possible versions conflict with previously selected packages.

      previously selected package `ink v4.1.0`
        ... which satisfies dependency `ink = "~4.1.0"` of package `assets_extension v0.1.0 (/tmp/chain-extension-contracts/crates/assets)`
        ... which satisfies path dependency `assets_extension` of package `asset_wrapper v0.1.0 (/tmp/chain-extension-contracts/examples/assets)`

    failed to select a version for `ink` which could resolve this conflict
